### PR TITLE
Adds compact

### DIFF
--- a/src/compact/compact.js
+++ b/src/compact/compact.js
@@ -68,6 +68,6 @@ const _compactMany = map(_compact)
  * //  f: lambda
  * // }
  */
-export const compact = curry(_compact)
+export const compact = _compact
 
-export const compactMany = curry(_compactMany)
+export const compactMany = _compactMany

--- a/src/compact/compact.js
+++ b/src/compact/compact.js
@@ -1,0 +1,40 @@
+import { forEach } from "../for-each/for-each"
+import { is } from "../is/is"
+import { map } from "../map/map"
+import { filter } from "../filter/filter"
+import { curry } from "../curry/curry"
+
+const _compactObject = source => {
+  const result = { ...source }
+
+  forEach(key => {
+    if (!is(result[key])) {
+      delete result[key]
+    }
+  }, Object.keys(result))
+
+  return result
+}
+
+const _compactArray = source => filter(is, source)
+
+const _compact = source => {
+  const type = Array.isArray(source) ? "array" : typeof source
+
+  switch (type) {
+    case "array":
+      return _compactArray(source)
+
+    case "object":
+      return _compactObject(source)
+
+    default:
+      return source
+  }
+}
+
+const _compactMany = source => map(item => _compact(item), source)
+
+export const compact = curry(_compact)
+
+export const compactMany = curry(_compactMany)

--- a/src/compact/compact.js
+++ b/src/compact/compact.js
@@ -1,17 +1,18 @@
-import { forEach } from "../for-each/for-each"
 import { is } from "../is/is"
 import { map } from "../map/map"
 import { filter } from "../filter/filter"
 import { curry } from "../curry/curry"
+import { type } from "../type/type"
 
 const _compactObject = source => {
   const result = { ...source }
+  const keys = Object.keys(result)
 
-  forEach(key => {
+  for (const key of keys) {
     if (!is(result[key])) {
       delete result[key]
     }
-  }, Object.keys(result))
+  }
 
   return result
 }
@@ -19,13 +20,13 @@ const _compactObject = source => {
 const _compactArray = source => filter(is, source)
 
 const _compact = source => {
-  const type = Array.isArray(source) ? "array" : typeof source
+  const sourceType = type(source)
 
-  switch (type) {
-    case "array":
+  switch (sourceType) {
+    case "Array":
       return _compactArray(source)
 
-    case "object":
+    case "Object":
       return _compactObject(source)
 
     default:
@@ -33,8 +34,40 @@ const _compact = source => {
   }
 }
 
-const _compactMany = source => map(item => _compact(item), source)
+const _compactMany = map(_compact)
 
+/**
+ * Returns a copy of the object or array
+ * with all null or undefined values removed
+ *
+ * @param {Array|Object} source
+ *
+ * @returns {Array|Object}
+ *
+ * @name compact
+ * @tag Array,Object
+ * @signature (source: Array|Object): Array|Object
+ *
+ * @see {@link compactMany}
+ * @see {@link is}
+ *
+ * @example
+ * compact([1, null, undefined, {}])
+ * // => [1, {}]
+ *
+ * compact({
+ *   a: "Lorem Ipsum",
+ *   b: null,
+ *   c: undefined,
+ *   d: false,
+ *   f: lambda,
+ *  }),
+ * // => {
+ * //  a: "Lorem Ipsum",
+ * //  d: false,
+ * //  f: lambda
+ * // }
+ */
 export const compact = curry(_compact)
 
 export const compactMany = curry(_compactMany)

--- a/src/compact/compact.test.js
+++ b/src/compact/compact.test.js
@@ -37,6 +37,10 @@ test("compact", t => {
 
   t.deepEqual(compact(""), "", "Compacting an empty string does nothing")
 
+  t.deepEqual(compact(null), null, "Compacting null does nothing")
+
+  t.deepEqual(compact(), undefined, "Compacting undefined does nothing")
+
   t.deepEqual(compact(false), false, "Compacting a boolean does nothing")
 
   t.deepEqual(compact(lambda), lambda, "Compacting a function does nothing")
@@ -51,6 +55,8 @@ test("compactMany", t => {
       { a: "Lorem Ipsum", b: null, c: undefined, d: false, f: lambda },
       "Lorem",
       "",
+      null,
+      undefined,
       false,
       lambda,
     ]),
@@ -59,6 +65,8 @@ test("compactMany", t => {
       { a: "Lorem Ipsum", d: false, f: lambda },
       "Lorem",
       "",
+      null,
+      undefined,
       false,
       lambda,
     ],

--- a/src/compact/compact.test.js
+++ b/src/compact/compact.test.js
@@ -1,0 +1,69 @@
+/* eslint-disable unicorn/no-null */
+import test from "tape"
+
+import { compact, compactMany } from "./compact"
+
+const lambda = () => null
+
+test("compact", t => {
+  t.deepEqual(
+    compact({
+      b: null,
+      c: undefined,
+    }),
+    {},
+    "Compacting an object should return compacted object"
+  )
+
+  t.deepEqual(
+    compact({
+      a: "Lorem Ipsum",
+      b: null,
+      c: undefined,
+      d: false,
+      f: lambda,
+    }),
+    { a: "Lorem Ipsum", d: false, f: lambda },
+    "Compacting an object should return compacted object"
+  )
+
+  t.deepEqual(
+    compact([1, null, undefined, false, "a", lambda]),
+    [1, false, "a", lambda],
+    "Compacting an array should return compacted array"
+  )
+
+  t.deepEqual(compact("Lorem"), "Lorem", "Compacting an string does nothing")
+
+  t.deepEqual(compact(""), "", "Compacting an empty string does nothing")
+
+  t.deepEqual(compact(false), false, "Compacting a boolean does nothing")
+
+  t.deepEqual(compact(lambda), lambda, "Compacting a function does nothing")
+
+  t.end()
+})
+
+test("compactMany", t => {
+  t.deepEqual(
+    compactMany([
+      [1, null, undefined, false, "a", lambda],
+      { a: "Lorem Ipsum", b: null, c: undefined, d: false, f: lambda },
+      "Lorem",
+      "",
+      false,
+      lambda,
+    ]),
+    [
+      [1, false, "a", lambda],
+      { a: "Lorem Ipsum", d: false, f: lambda },
+      "Lorem",
+      "",
+      false,
+      lambda,
+    ],
+    "Compacting an array of things compacts each of them"
+  )
+
+  t.end()
+})


### PR DESCRIPTION
Compact is heavily inspired by Ruby / Rails counterpart, that supports both [arrays](https://apidock.com/ruby/v2_6_3/Array/compact) and [hashes](https://apidock.com/rails/Hash/compact). 

I find it one most useful when dealing with real world data arrays and hashes. I made it ignore other types. 

Let me know what do you think or if you need any changes on the code.