### PR TITLE
Improve spy output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,4 @@ dist/
 
 # Vim ctags
 tags
+.dccache

--- a/src/spy/spy.js
+++ b/src/spy/spy.js
@@ -1,28 +1,36 @@
+import { is } from "../is/is"
+
 /**
  * Proxy input and print to console.log. Useful for debugging pipe chains.
  *
- * @param {string} namespace
+ * @param {Object} props
  * @param {any}    source
  *
  * @returns {any}
  *
  * @name      spy
  * @tag       Other
- * @signature (namespace: string) => (source: any): any
+ * @signature (...props: any) => (source: any): any
  *
  * @example
  */
-export const spy = namespace => (...source) => {
+export const spy = (props = {}) => (...source) => {
   if (source.length > 1) {
     throw new Error(
-      `m:spy - Can only be called with 1 parameter, received ${source.length}`
+      `@asd14/m/spy - Can only be called with 1 parameter, received ${source.length}`
     )
   }
 
-  const payload = source[0]
-  const spied = [Object, Array].includes(payload.constructor) ? payload : JSON.stringify(payload)
+  const { description = "@asd14/m/spy", transform } = props
 
-  console.log(`m:spy:${namespace}`, spied)
+  const spyValue = is(transform) ? transform(source[0]) : source[0]
 
-  return payload
+  console.log()
+  console.log(`// ${description}`)
+  console.log()
+
+  console.log(JSON.stringify(spyValue, null, 2))
+
+  // Make sure we're just proxying input
+  return source[0]
 }

--- a/src/spy/spy.js
+++ b/src/spy/spy.js
@@ -1,5 +1,5 @@
 /**
- * Proxy input and print to console.log. Usefull for debugging pipe chains.
+ * Proxy input and print to console.log. Useful for debugging pipe chains.
  *
  * @param {string} namespace
  * @param {any}    source
@@ -19,7 +19,10 @@ export const spy = namespace => (...source) => {
     )
   }
 
-  console.log(`m:spy:${namespace}`, JSON.stringify(source[0]))
+  const payload = source[0]
+  const spied = [Object, Array].includes(payload.constructor) ? payload : JSON.stringify(payload)
 
-  return source[0]
+  console.log(`m:spy:${namespace}`, spied)
+
+  return payload
 }

--- a/src/spy/spy.test.js
+++ b/src/spy/spy.test.js
@@ -3,14 +3,37 @@
 import { describe, Try } from "riteway"
 
 import { pipe } from "../pipe/pipe"
+import { top } from "../top/top"
 import { spy } from "./spy"
+
+const example = [{ id: 1 }, { id: 2 }, { id: "uuid" }]
 
 describe("spy", async assert => {
   assert({
+    given: "no arguments pipe",
+    should: "return initial source value",
+    actual: pipe(spy(), source => source)(2),
+    expected: 2,
+  })
+
+  assert({
     given: "unary pipe",
-    should: "return initial souce value",
+    should: "return initial source value",
     actual: pipe(spy("test"), source => source)(2),
     expected: 2,
+  })
+
+  assert({
+    given: "slicing and transformations",
+    should: "return initial source value",
+    actual: pipe(
+      spy({
+        description: "First 2 items",
+        transform: top(2),
+      }),
+      source => source
+    )(example),
+    expected: example,
   })
 
   assert({
@@ -21,6 +44,7 @@ describe("spy", async assert => {
       2,
       3
     ).toString(),
-    expected: "Error: m:spy - Can only be called with 1 parameter, received 2",
+    expected:
+      "Error: @asd14/m/spy - Can only be called with 1 parameter, received 2",
   })
 })


### PR DESCRIPTION
spy is not very useful for long collections or objects when passed through a `JSON.stringify`, removing it for those two.