### PR TITLE
Adds partitionBy

### DIFF
--- a/src/partition/partition.js
+++ b/src/partition/partition.js
@@ -4,6 +4,9 @@ import { pipe } from "../pipe/pipe"
 import { reduce } from "../reduce/reduce"
 import { curry } from "../curry/curry"
 import { isMatch } from "../is-match/is-match"
+import { is } from "../is/is"
+import { map } from "../map/map"
+import { distinct } from "../distinct/distinct"
 
 const _partition = (_fn, source) => {
   const fn = Array.isArray(_fn) ? pipe(..._fn) : _fn
@@ -19,6 +22,33 @@ const _partition = (_fn, source) => {
   }
 
   return [pass, fail]
+}
+
+const _partitionBy = (key, source) => {
+  const result = [...source]
+
+  const values = pipe(
+    map(item => item[key]),
+    distinct
+  )(result)
+
+  const partitioner = (acc, item) => {
+    const partIndex = values.indexOf(item[key])
+
+    if (partIndex === -1) {
+      return acc
+    }
+
+    if (is(acc[partIndex])) {
+      acc[partIndex].push(item)
+    } else {
+      acc[partIndex] = [item]
+    }
+
+    return acc
+  }
+
+  return reduce(partitioner, [])(result)
 }
 
 /**
@@ -64,3 +94,5 @@ export const partition = curry(_partition)
 export const partitionWith = curry((subset, source) =>
   _partition(isMatch(subset), source)
 )
+
+export const partitionBy = curry(_partitionBy)

--- a/src/partition/partition.test.js
+++ b/src/partition/partition.test.js
@@ -2,7 +2,7 @@ import test from "tape"
 
 import { is } from "../is/is"
 import { read } from "../read/read"
-import { partition, partitionWith } from "./partition"
+import { partition, partitionWith, partitionBy } from "./partition"
 
 const equalsTwo = x => x === 2
 
@@ -47,6 +47,26 @@ test("partitionWith", t => {
     })([{ id: 1 }, { id: 2, parentId: 1 }]),
     [[{ id: 2, parentId: 1 }], [{ id: 1 }]],
     "partitionWith({parentId: is}) // => [[{parentId: 1}], [{id: 1}]]"
+  )
+
+  t.end()
+})
+
+test("partitionBy", t => {
+  t.deepEqual(
+    partitionBy("id")([
+      { id: 1 },
+      { id: 1 },
+      { id: 2, parentId: 1 },
+      { id: 1, parentId: 1 },
+      { parentId: 1 },
+    ]),
+    [
+      [{ id: 1 }, { id: 1 }, { id: 1, parentId: 1 }],
+      [{ id: 2, parentId: 1 }],
+      [{ parentId: 1 }],
+    ],
+    "partitionBy('id')"
   )
 
   t.end()


### PR DESCRIPTION
I find useful to partition collections of objects by one of their keys, normally to then call `maxBy` or other processing to then `flatten`. Adding a `partitionBy` makes sense to me, let me know if naming feels ok or any changes are required to make this PR acceptable. 

Thanks!