### PR TITLE
feat: add `values` function

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -48,6 +48,7 @@ export { pick } from "./pick/pick"
 export { pluck } from "./pluck/pluck"
 export { merge, mergeAll, mergeBy } from "./merge/merge"
 export { keys } from "./keys/keys"
+export { values } from "./values/values"
 export { rename as renameKeys, rename, renameMany } from "./rename/rename"
 export {
   zipToObject as zipToObj,

--- a/src/values/values.js
+++ b/src/values/values.js
@@ -28,7 +28,7 @@ export const values = source => {
 
   switch (type) {
     case "array": {
-      return source
+      return [...source]
     }
     case "object": {
       const entries = Object.entries(source)

--- a/src/values/values.js
+++ b/src/values/values.js
@@ -1,0 +1,46 @@
+/**
+ * Get list with names of all own properties
+ *
+ * @param {Array|Object} source Array or Object to extract values from
+ *
+ * @returns {string[]} List of property names
+ *
+ * @name values
+ * @tag Array,Object
+ * @signature (source: Array|Object): string[]
+ *
+ * @example
+ * values(["lorem", "ipsum"])
+ * // => ["0", "1"]
+ *
+ * values({ foo: "bar", lorem: "ipsum"})
+ * // => ["bar", "ipsum"]
+ *
+ * values("foo"), values(12), values(null), etc
+ * // => []
+ */
+export const values = source => {
+  const type = Array.isArray(source)
+    ? "array"
+    : source !== null && typeof source === "object"
+    ? "object"
+    : "other"
+
+  switch (type) {
+    case "array": {
+      return source
+    }
+    case "object": {
+      const entries = Object.entries(source)
+      const result = []
+
+      for (const entry of entries) {
+        result.push(entry[1])
+      }
+
+      return result
+    }
+    default:
+      return []
+  }
+}

--- a/src/values/values.js
+++ b/src/values/values.js
@@ -11,7 +11,7 @@
  *
  * @example
  * values(["lorem", "ipsum"])
- * // => ["0", "1"]
+ * // => ["lorem", "ipsum"]
  *
  * values({ foo: "bar", lorem: "ipsum"})
  * // => ["bar", "ipsum"]

--- a/src/values/values.test.js
+++ b/src/values/values.test.js
@@ -1,0 +1,31 @@
+import test from "tape"
+
+import { values } from "./values"
+
+test("values", t => {
+  t.deepEquals(
+    values(["test", 1, 2]),
+    ["test", 1, 2],
+    "When passing an array, should return the same array"
+  )
+
+  t.deepEquals(
+    values({ foo: "bar", lorem: "ipsum" }),
+    ["bar", "ipsum"],
+    "When passing an object, should return an array of strings with the values"
+  )
+
+  t.deepEquals(
+    values("lorem"),
+    [],
+    "When passing a string, should return an empty array"
+  )
+
+  t.deepEquals(
+    values(12),
+    [],
+    "when passing a number, should return an empty array"
+  )
+
+  t.end()
+})


### PR DESCRIPTION
Add function `values`, as a counterpart to existing `keys`. I opted to behave as the identity when used on arrays, but this is just a convention that can be changed.

## Checklist

- [x] Tests
- [x] JSDocs
- [x] Export in `src/index.js`
