### PR TITLE
fix: starts-with/ends-with should be able to handle null/undefined input

### DIFF
--- a/src/ends-with/ends-with.js
+++ b/src/ends-with/ends-with.js
@@ -2,11 +2,14 @@ import { curry } from "../curry/curry.js"
 import { is } from "../is/is.js"
 
 const _endsWith = (search, input) => {
-  if (!is(input)) {
+  const inputIsString = typeof input === "string"
+  const inputIsArray = Array.isArray(input)
+
+  if (!(inputIsString || inputIsArray)) {
     return false
   }
 
-  if (search.length > input.length) {
+  if (!is(search)) {
     return false
   }
 
@@ -16,7 +19,11 @@ const _endsWith = (search, input) => {
     return false
   }
 
-  return searchPosition === input.length - search.length
+  const targetPosition = inputIsString
+    ? input.length - search.length
+    : input.length - 1
+
+  return searchPosition === targetPosition
 }
 
 /**

--- a/src/ends-with/ends-with.js
+++ b/src/ends-with/ends-with.js
@@ -1,6 +1,11 @@
 import { curry } from "../curry/curry.js"
+import { is } from "../is/is.js"
 
 const _endsWith = (search, input) => {
+  if (!is(input)) {
+    return false
+  }
+
   if (search.length > input.length) {
     return false
   }

--- a/src/ends-with/ends-with.test.js
+++ b/src/ends-with/ends-with.test.js
@@ -34,9 +34,51 @@ test("endsWith", t => {
     "Search string does not exist in source"
   )
 
+  t.equals(
+    endsWith("ipsum")(["lorem", "ipsum"]),
+    true,
+    "Search in Array should return true if the entry is the exactly the last"
+  )
+
+  t.equals(
+    endsWith("ipsum")(["lorem", "loremipsum"]),
+    false,
+    "Search in Array should not return true if the entry if its just starting but not exactly the last"
+  )
+
+  t.equals(
+    endsWith("")(["lorem"]),
+    false,
+    "Search in Array should returns false if searching for empty string"
+  )
+
+  t.equals(
+    endsWith("lorem")([]),
+    false,
+    "Search in Array should returns false if empty"
+  )
+
+  t.equals(
+    endsWith(null)([]),
+    false,
+    "Search in Array should returns false if empty, even if searching for null"
+  )
+
+  t.equals(
+    endsWith(null)([null]),
+    false,
+    "Search in Array should not consider a 'null' entry as searchable, even if it matches the last entry"
+  )
+
   t.equals(endsWith("lorem")(null), false, "Search null returns false")
 
   t.equals(endsWith("lorem")(), false, "Search undefined returns false")
+
+  t.equals(
+    endsWith("lorem")({ lorem: "lorem" }),
+    false,
+    "Search in Object should returns false"
+  )
 
   t.end()
 })

--- a/src/ends-with/ends-with.test.js
+++ b/src/ends-with/ends-with.test.js
@@ -1,3 +1,4 @@
+/* eslint-disable unicorn/no-null */
 import test from "tape"
 
 import { endsWith } from "./ends-with.js"
@@ -32,6 +33,10 @@ test("endsWith", t => {
     false,
     "Search string does not exist in source"
   )
+
+  t.equals(endsWith("lorem")(null), false, "Search null returns false")
+
+  t.equals(endsWith("lorem")(), false, "Search undefined returns false")
 
   t.end()
 })

--- a/src/starts-with/starts-with.js
+++ b/src/starts-with/starts-with.js
@@ -1,6 +1,11 @@
 import { curry } from "../curry/curry.js"
+import { is } from "../is/is.js"
 
 const _startsWith = (search, input) => {
+  if (!is(input)) {
+    return false
+  }
+
   const searchPosition = input.indexOf(search)
 
   if (searchPosition === -1) {

--- a/src/starts-with/starts-with.js
+++ b/src/starts-with/starts-with.js
@@ -1,18 +1,16 @@
-import { curry } from "../curry/curry.js"
 import { is } from "../is/is.js"
+import { curry } from "../curry/curry.js"
 
 const _startsWith = (search, input) => {
-  if (!is(input)) {
+  if (!(typeof input === "string" || Array.isArray(input))) {
     return false
   }
 
-  const searchPosition = input.indexOf(search)
-
-  if (searchPosition === -1) {
+  if (!is(search)) {
     return false
   }
 
-  return searchPosition === 0
+  return input.indexOf(search) === 0
 }
 
 /**

--- a/src/starts-with/starts-with.test.js
+++ b/src/starts-with/starts-with.test.js
@@ -1,3 +1,4 @@
+/* eslint-disable unicorn/no-null */
 import test from "tape"
 
 import { startsWith } from "./starts-with.js"
@@ -38,6 +39,10 @@ test("startsWith", t => {
     true,
     "Search item inside array"
   )
+
+  t.equals(startsWith("lorem")(null), false, "Search null returns false")
+
+  t.equals(startsWith("lorem")(), false, "Search undefined returns false")
 
   t.end()
 })

--- a/src/starts-with/starts-with.test.js
+++ b/src/starts-with/starts-with.test.js
@@ -40,9 +40,51 @@ test("startsWith", t => {
     "Search item inside array"
   )
 
+  t.equals(
+    startsWith("lorem")(["lorem", "ipsum"]),
+    true,
+    "Search in Array should returns true if the entry if its the exactly the first"
+  )
+
+  t.equals(
+    startsWith("lorem")(["loremipsum", "ipsum"]),
+    false,
+    "Search in Array should not return true if the entry if its just starting but not exactly the first"
+  )
+
+  t.equals(
+    startsWith("")(["lorem"]),
+    false,
+    "Search in Array should returns false if searching for empty string"
+  )
+
+  t.equals(
+    startsWith("lorem")([]),
+    false,
+    "Search in Array should returns false if empty"
+  )
+
+  t.equals(
+    startsWith(null)([]),
+    false,
+    "Search in Array should returns false if empty, even if searching for null"
+  )
+
+  t.equals(
+    startsWith(null)([null]),
+    false,
+    "Search null in Array should returns false, even if it matches the first entry"
+  )
+
   t.equals(startsWith("lorem")(null), false, "Search null returns false")
 
   t.equals(startsWith("lorem")(), false, "Search undefined returns false")
+
+  t.equals(
+    startsWith("lorem")({ lorem: "lorem" }),
+    false,
+    "Search in Object should returns false"
+  )
 
   t.end()
 })


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 -->

## Primary

1. Fix bug in starts-with when null/undefined input is provided
1. Fix bug in ends-with when null/undefined input is provided

## Checklist

- [x] Tests
- [ ] JSDocs
- [x] Export in `src/index.js`
